### PR TITLE
Open data complete

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@electron-toolkit/eslint-config": "^1.0.1",
         "@electron-toolkit/eslint-config-prettier": "^1.0.1",
         "@vitejs/plugin-react": "^4.0.4",
-        "electron": "^25.6.0",
+        "electron": "^25.9.8",
         "electron-builder": "^24.6.3",
         "electron-vite": "^1.0.27",
         "eslint": "^8.47.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@electron-toolkit/eslint-config": "^1.0.1",
     "@electron-toolkit/eslint-config-prettier": "^1.0.1",
     "@vitejs/plugin-react": "^4.0.4",
-    "electron": "^25.6.0",
+    "electron": "^25.9.8",
     "electron-builder": "^24.6.3",
     "electron-vite": "^1.0.27",
     "eslint": "^8.47.0",

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -1,7 +1,15 @@
-import { app, shell, BrowserWindow } from 'electron'
+import { app, shell, BrowserWindow, dialog, ipcMain } from 'electron'
 import { join } from 'path'
 import { electronApp, optimizer, is } from '@electron-toolkit/utils'
+import { readdir } from 'fs/promises'
 import icon from '../../resources/icon.png?asset'
+
+async function handleFolderOpen() {
+  const { canceled, filePaths } = await dialog.showOpenDialog({});
+  if (!canceled) {
+    return filePaths[0];
+  }
+}
 
 function createWindow() {
   // Create the browser window.
@@ -12,9 +20,9 @@ function createWindow() {
     autoHideMenuBar: true,
     ...(process.platform === 'linux' ? { icon } : {}),
     webPreferences: {
-      nodeIntegration: true,
       preload: join(__dirname, '../preload/index.js'),
-      sandbox: false
+      sandbox: false,
+      webSecurity: false
     }
   })
 
@@ -49,6 +57,8 @@ app.whenReady().then(() => {
   app.on('browser-window-created', (_, window) => {
     optimizer.watchWindowShortcuts(window)
   })
+
+  ipcMain.handle('dialog:openDirectory', handleFolderOpen);
 
   createWindow()
 

--- a/src/preload/index.js
+++ b/src/preload/index.js
@@ -1,20 +1,24 @@
-import { contextBridge } from 'electron'
+import { contextBridge, ipcRenderer } from 'electron'
 import { electronAPI } from '@electron-toolkit/preload'
 
 // Custom APIs for renderer
 const api = {}
 
+contextBridge.exposeInMainWorld('electronAPI', {
+  openFolder: () => ipcRenderer.invoke('dialog:openDirectory')
+});
+
 // Use `contextBridge` APIs to expose Electron APIs to
 // renderer only if context isolation is enabled, otherwise
 // just add to the DOM global.
-if (process.contextIsolated) {
-  try {
-    contextBridge.exposeInMainWorld('electron', electronAPI)
-    contextBridge.exposeInMainWorld('api', api)
-  } catch (error) {
-    console.error(error)
-  }
-} else {
-  window.electron = electronAPI
-  window.api = api
-}
+// if (process.contextIsolated) {
+//   try {
+//     contextBridge.exposeInMainWorld('electron', electronAPI)
+//     contextBridge.exposeInMainWorld('api', api)
+//   } catch (error) {
+//     console.error(error)
+//   }
+// } else {
+//   window.electron = electronAPI
+//   window.api = api
+// }

--- a/src/renderer/src/App.jsx
+++ b/src/renderer/src/App.jsx
@@ -1,12 +1,18 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Sidebar, VariantForm } from './components'
 
 function App() {
   const [selectedVariants, setSelectedVariants] = useState([])
 
+    async function handleFolder() {
+      const filePath = await window.electronAPI.openFolder()
+      console.log(filePath)
+    }
+
   return (
     <>
       <h1>ElDewrito Voting JSON Builder</h1>
+      <button id='button' onClick={handleFolder}>open folder</button>
       <Sidebar />
       <div className="container">
         {selectedVariants.map((i) => {


### PR DESCRIPTION
fixed dialog not allowing user to select directory instead of files and now added completed logic to read the names of the appropriate files from the explicitly typed directories and return data to the frontend over ipcRenderer