### PR TITLE
fix jsondata maps array not being populated correctly

### DIFF
--- a/src/renderer/src/App.jsx
+++ b/src/renderer/src/App.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Sidebar, VariantForm } from './components'
 import background from '../src/assets/background.webm'
 
@@ -11,13 +11,16 @@ function App() {
     if (Array.isArray(res.maps) && Array.isArray(res.variants)) {
       setData(res)
     }
-    const mapObjects = data.maps.map((i) => ({ displayName: i, mapName: i }))
-    setJsonData({ ...jsonData, Maps: mapObjects })
   }
 
   async function handleSave() {
     const res = await window.electronAPI.saveFile(jsonData)
   }
+
+  useEffect(()=>{
+    const mapObjects = data.maps.map((i) => ({ displayName: i, mapName: i }))
+    setJsonData({ ...jsonData, Maps: mapObjects })
+  },[data])
 
   return (
     <>


### PR DESCRIPTION
fixed an issue in test build where the Maps array in the jsondata state was not being populated correctly without opening the mods folder containing the maps and variants folders multiple times in order to save a valid voting.json. merge back into styling branch to continue styling before final steps to push to prod